### PR TITLE
modified atmodat_data_checker_recommended.yml

### DIFF
--- a/atmodat_data_checker_recommended.yml
+++ b/atmodat_data_checker_recommended.yml
@@ -50,6 +50,10 @@ checks:
     parameters: {"attribute": "title", "type": str, "status": "recommended"}
     check_name: "atmodat_checklib.register.GlobalAttrTypeCheck"
 
+  - check_id: "vertical_resolution_attribute_type_check"
+    parameters: {"attribute": "geospatial_vertical_resolution", "type": str, "status": "recommended"}
+    check_name: "atmodat_checklib.register.GlobalAttrTypeCheck"
+
   # 2. CV Checks
 
   - check_id: "frequency_attribute_check"
@@ -81,10 +85,5 @@ checks:
 
   - check_id: "global_attribute_resolution_format_check_lon_resolution"
     parameters: {"attribute": "geospatial_lon_resolution",
-                 "status": "recommended"}
-    check_name: "atmodat_checklib.register.GobalAttrResolutionFormatCheck"
-
-  - check_id: "global_attribute_resolution_format_check_vertical_resolution"
-    parameters: {"attribute": "geospatial_vertical_resolution",
                  "status": "recommended"}
     check_name: "atmodat_checklib.register.GobalAttrResolutionFormatCheck"


### PR DESCRIPTION
Hi Jan, 
ich habe die Prüfung des global attribute geospatial_vertical_resolution von Number+udunits auf ein einfachen String umgeändert, so wie das im ACCD vocabulary im ATMODAT Standard festgelegt ist. LG Angelika