### PR TITLE
Avoid checking for the Conventions attribute twice and fixing some typos

### DIFF
--- a/atmodat_checklib/register/nc_file_checks_atmodat_register.py
+++ b/atmodat_checklib/register/nc_file_checks_atmodat_register.py
@@ -59,14 +59,19 @@ class ConventionsVersionCheck(NCFileCheckBase):
 
         self._define_messages(messages)
 
-        if score < self.out_of:
-            messages.append(self.get_messages()[score])
+        if score == 0:
+            # The existence of the "Conventions" attribute is already checked by GlobalAttrTypeCheck, so no output of an
+            # error message is needed here
+            return
+        else:
+            if score < self.out_of:
+                messages.append(self.get_messages()[score])
 
-        return Result(self.level, (score, self.out_of),
-                      self.get_short_name(), messages)
+            return Result(self.level, (score, self.out_of),
+                          self.get_short_name(), messages)
 
 
-class GobalAttrResolutionFormatCheck(NCFileCheckBase):
+class GlobalAttrResolutionFormatCheck(NCFileCheckBase):
     """
     The global attribute '{attribute}' must be in number+unit format .
     """

--- a/atmodat_checklib/test/test_nc_file_checks_atmodat_register.py
+++ b/atmodat_checklib/test/test_nc_file_checks_atmodat_register.py
@@ -6,7 +6,7 @@ Unit tests for the contents of the atmodat_checklib.register.nc_file_checks_atmo
 import numpy as np
 import pytest
 from atmodat_checklib.register.nc_file_checks_atmodat_register import ConventionsVersionCheck, \
-    GlobalAttrTypeCheck, DateISO8601Check, GobalAttrResolutionFormatCheck
+    GlobalAttrTypeCheck, DateISO8601Check, GlobalAttrResolutionFormatCheck
 import datetime
 import pytz
 from netCDF4 import Dataset
@@ -78,8 +78,7 @@ def test_cf_conventions_conventions_missing(empty_netcdf):
     x = ConventionsVersionCheck(kwargs={"status": "mandatory", "attribute": "Conventions", "convention_type": "CF",
                                         "min_version": min_range, "max_version": max_range})
     resp = x(ds)
-    assert_output_msgs_len(resp)
-    assert(resp.value == (0, 3)), resp.msgs
+    assert(resp is None), resp.msgs
     ds.close()
 
 
@@ -89,8 +88,7 @@ def test_atmodat_conventions_not_present(empty_netcdf):
     x = ConventionsVersionCheck(kwargs={"status": "mandatory", "attribute": "Conventions", "convention_type": "ATMODAT",
                                         "min_version": min_range, "max_version": max_range})
     resp = x(ds)
-    assert_output_msgs_len(resp)
-    assert(resp.value == (0, 3)), resp.msgs
+    assert(resp is None), resp.msgs
     ds.close()
 
 
@@ -209,7 +207,7 @@ def test_date_iso8601_check_invalid_timestring(empty_netcdf):
 def test_gobal_attr_resolution_format_check_missing(empty_netcdf):
     for attr in ['geospatial_lon_resolution', 'geospatial_lat_resolution', 'geospatial_vertical_resolution']:
         ds = write_global_attribute(empty_netcdf)
-        x = GobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
+        x = GlobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
         resp = x(ds)
         assert_output_msgs_len(resp)
         assert(resp.value == (0, 4)), resp.msgs
@@ -221,7 +219,7 @@ def test_gobal_attr_resolution_format_check_no_value(empty_netcdf):
         for unit in ['W', ' W', 'W ']:
             attr_dict = {attr: unit}
             ds = write_global_attribute(empty_netcdf, **attr_dict)
-            x = GobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
+            x = GlobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
             resp = x(ds)
             assert_output_msgs_len(resp)
             assert(resp.value == (1, 4)), resp.msgs
@@ -233,7 +231,7 @@ def test_gobal_attr_resolution_format_check_no_unit(empty_netcdf):
         for attr in ['geospatial_lon_resolution', 'geospatial_lat_resolution', 'geospatial_vertical_resolution']:
             attr_dict = {attr: str(val)}
             ds = write_global_attribute(empty_netcdf, **attr_dict)
-            x = GobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
+            x = GlobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
             resp = x(ds)
             assert_output_msgs_len(resp)
             assert(resp.value == (2, 4)), resp.msgs
@@ -246,7 +244,7 @@ def test_gobal_attr_resolution_format_check_invalid_unit(empty_netcdf):
             for attr in ['geospatial_lon_resolution', 'geospatial_lat_resolution', 'geospatial_vertical_resolution']:
                 attr_dict = {attr: str(val) + ' ' + unit}
                 ds = write_global_attribute(empty_netcdf, **attr_dict)
-                x = GobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
+                x = GlobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
                 resp = x(ds)
                 assert_output_msgs_len(resp)
                 assert(resp.value == (3, 4)), resp.msgs
@@ -259,7 +257,7 @@ def test_gobal_attr_resolution_format_check_correct(empty_netcdf):
             for attr in ['geospatial_lon_resolution', 'geospatial_lat_resolution', 'geospatial_vertical_resolution']:
                 attr_dict = {attr: str(val) + ' ' + unit}
                 ds = write_global_attribute(empty_netcdf, **attr_dict)
-                x = GobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
+                x = GlobalAttrResolutionFormatCheck(kwargs={"status": "recommended", "attribute": attr})
                 resp = x(ds)
                 assert_output_msgs_len(resp)
                 assert(resp.value == (4, 4)), resp.msgs

--- a/atmodat_checklib/utils/nc_util.py
+++ b/atmodat_checklib/utils/nc_util.py
@@ -15,7 +15,7 @@ def check_conventions_version_number(ds, attr, conv_type, min_ver, max_ver):
     :param conv_type: Name of convention string to be checked for version
     :param min_ver: Minimum version allowed
     :param max_ver: Maximum version allowed
-    :return: Integer (0: not found; 1: convention to be checked fot not found; 2: convention out of valid range;
+    :return: Integer (0: not found; 1: convention to be checked for not found; 2: convention out of valid range;
     3: all correct)
     """
 

--- a/atmodat_standard_checks.yml
+++ b/atmodat_standard_checks.yml
@@ -14,6 +14,10 @@ checks:
     parameters: {"attribute": "source", "type": "str", "status": "mandatory"}
     check_name: "atmodat_checklib.register.GlobalAttrTypeCheck"
 
+  - check_id: "source_attribute_type_check"
+    parameters: {"attribute": "Conventions", "type": "str", "status": "mandatory"}
+    check_name: "atmodat_checklib.register.GlobalAttrTypeCheck"
+
   # Check if Conventions version is within given range
   - check_id: "cf_conventions_version_check"
     parameters: {"attribute": "Conventions", "convention_type": "CF", "min_version": 1.4, "max_version": 1.8,
@@ -102,12 +106,12 @@ checks:
   - check_id: "global_attribute_resolution_format_check_lat_resolution"
     parameters: {"attribute": "geospatial_lat_resolution",
                  "status": "recommended"}
-    check_name: "atmodat_checklib.register.GobalAttrResolutionFormatCheck"
+    check_name: "atmodat_checklib.register.GlobalAttrResolutionFormatCheck"
 
   - check_id: "global_attribute_resolution_format_check_lon_resolution"
     parameters: {"attribute": "geospatial_lon_resolution",
                  "status": "recommended"}
-    check_name: "atmodat_checklib.register.GobalAttrResolutionFormatCheck"
+    check_name: "atmodat_checklib.register.GlobalAttrResolutionFormatCheck"
 
   - check_id: "vertical_resolution_attribute_type_check"
     parameters: {"attribute": "geospatial_vertical_resolution", "type": "str", "status": "recommended"}

--- a/run_checks.py
+++ b/run_checks.py
@@ -24,6 +24,13 @@ def run_checks(ifile_in, verbose_in, check_types_in, cfversion_in):
             if verbose_in:
                 os.system('cchecker.py --y ' + idiryml
                           + '/atmodat_standard_checks.yml --test atmodat_standard:3.0 ' + ifile_in)
+                if 'CF' in check_types_in:
+                    print('')
+                    print('')
+                    print('==============================================================================')
+                    print('===============================CF-Checker=====================================')
+                    print('==============================================================================')
+                    print('')
         else:
             os.system(
                 'cfchecks -v ' + cfversion_in + ' ' + ifile_in + '>> ' + opath + '/CF/' + filename_base


### PR DESCRIPTION
Avoid checking for the Conventions attribute twice and fixing some typos