### PR TITLE
Speed up checking of mutilple netCDF files

### DIFF
--- a/atmodat_checklib/result_output/summary_creation.py
+++ b/atmodat_checklib/result_output/summary_creation.py
@@ -161,7 +161,7 @@ def create_output_summary(file_counter, opath, check_types_in):
         if file.endswith("_result.json") and isinstance(json_summary, pd.DataFrame):
             json_summary = json_summary.append(extract_overview_output_json(file),
                                                ignore_index=True)
-        elif file.endswith("_cfchecks_result.txt"):
+        elif file.endswith("_CF_result.txt"):
             cf_errors, std_name_table = extracts_error_summary_cf_check(file, cf_errors)
 
     write_short_summary(json_summary, cf_errors, file_counter, std_name_table, opath)

--- a/run_checks.py
+++ b/run_checks.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 import atmodat_checklib.result_output.output_directory as output_directory
 import atmodat_checklib.result_output.summary_creation as summary_creation
+import subprocess
 
 idiryml = str(Path(__file__).resolve().parents[0])
 
@@ -13,30 +14,48 @@ idiryml = str(Path(__file__).resolve().parents[0])
 def run_checks(ifile_in, verbose_in, check_types_in, cfversion_in):
     """run all checks"""
     # Get base filename and output path
-    filename_base = ifile_in.split("/")[-1].rstrip('.nc')
+    filenames_base = [f.split("/")[-1].rstrip('.nc') for f in ifile_in]
+    ifile_in_string = " ".join(ifile_in)
     for check in check_types_in:
         if check != 'CF':
-            os.system(
-                'cchecker.py --y ' + idiryml
-                + '/atmodat_standard_checks.yml -f json_new -o ' + opath
-                + '/' + check + '/' + filename_base + '_' + check
-                + '_result.json --test atmodat_standard:3.0 ' + ifile_in)
-            if verbose_in:
-                os.system('cchecker.py --y ' + idiryml
-                          + '/atmodat_standard_checks.yml --test atmodat_standard:3.0 ' + ifile_in)
-                if 'CF' in check_types_in:
-                    print('')
-                    print('')
-                    print('==============================================================================')
-                    print('===============================CF-Checker=====================================')
-                    print('==============================================================================')
-                    print('')
+            ofiles_checker = [opath + check + '/' + filename_base + '_' + check + '_result.json'
+                              for filename_base in filenames_base]
+            ofiles_checker = ['-o ' + ofile for ofile in ofiles_checker]
+            ofiles_checker_string = " ".join(ofiles_checker)
+            cmd = 'cchecker.py --y ' + idiryml + '/atmodat_standard_checks.yml -f json_new -f text ' + \
+                  ofiles_checker_string + ' --test atmodat_standard:3.0 ' + ifile_in_string
+            subprocess.run(cmd, shell=True)
         else:
-            os.system(
-                'cfchecks -v ' + cfversion_in + ' ' + ifile_in + '>> ' + opath + '/CF/' + filename_base
-                + '_cfchecks_result.txt')
+            cmd = 'cfchecks -v ' + cfversion_in + ' ' + ifile_in_string
+            output_string = subprocess.run(cmd, shell=True, capture_output=True, text=True).stdout
+            split_string = 'CHECKING NetCDF FILE'
+            output_string_files = output_string.split(split_string)[1::]
+            for ofile_data_cf in zip(filenames_base, output_string_files):
+                ofile_cf = opath + 'CF/' + ofile_data_cf[0] + '_' + check + '_result.txt'
+                with open(ofile_cf, 'w', encoding='utf-8') as f_cf:
+                    f_cf.write(split_string + ofile_data_cf[1])
+    for filename_base in filenames_base:
+        for check in check_types_in:
+            file_verbose = opath + check + '/' + filename_base + '_' + check + '_result.txt'
             if verbose_in:
-                os.system('cfchecks -v ' + cfversion_in + ' ' + ifile_in)
+                with open(file_verbose, 'r', encoding='utf-8') as f_verbose:
+                    if check == 'CF':
+                        print('')
+                        print('==============================================================================')
+                        print('===============================CF-Checker=====================================')
+                        print('==============================================================================')
+                        print('')
+                        print(f_verbose.read())
+                    elif check == 'atmodat':
+                        print('')
+                        print('==============================================================================')
+                        print('===============================AtMoDat-Checks=================================')
+                        print('==============================================================================')
+                        print('')
+                        print(f_verbose.read())
+            # Clean-up
+            if check == 'atmodat':
+                os.remove(file_verbose)
     return
 
 
@@ -117,6 +136,7 @@ if __name__ == "__main__":
         check_types.remove('CF')
 
     # Create directory for checker output
+    opath = idiryml + '/checker_output/tmp/'
     output_directory.create_directories(opath, check_types)
 
     # Run checks
@@ -124,18 +144,21 @@ if __name__ == "__main__":
     if ifile and not ipath:
         if ifile.endswith(".nc"):
             if os.path.isfile(ifile):
-                run_checks(ifile, verbose, check_types, cfversion)
-                file_counter = file_counter + 1
+                run_checks([ifile], verbose, check_types, cfversion)
+                file_counter = 1
             else:
                 raise RuntimeError('File: ' + ifile + ' does not exist')
         else:
             print('Skipping ' + ifile + ' as it does not end with ".nc'"")
     elif ipath and not ifile:
-        files = output_directory.return_files_in_directory_tree(ipath)
-        for file in files:
-            if file.endswith(".nc"):
-                run_checks(file, verbose, check_types, cfversion)
-                file_counter = file_counter + 1
+        files_all = output_directory.return_files_in_directory_tree(ipath)
+        file_nc = []
+        [file_nc.append(file) for file in files_all if file.endswith(".nc")]
+        if len(file_nc) == 0:
+            raise RuntimeError('No netCDF files found in: ' + ipath)
+        else:
+            run_checks(file_nc, verbose, check_types, cfversion)
+            file_counter = len(file_nc)
 
     # Create summary of results if specified
     if parsed_summary:
@@ -143,5 +166,3 @@ if __name__ == "__main__":
 
     # Calculate run time of this script
     print("--- %.4f seconds for checking %s files---" % ((datetime.now() - start_time).total_seconds(), file_counter))
-
-    exit()


### PR DESCRIPTION
Resolves #64 and resolves #58
This PR speeds up the checking of multiple netCDF files. In testing, a speed up of 100% could be achieved. An even further speed up could be achieved for the verbose mode.
Furthermore, the information form pyessv printed in the terminal will only be displayed once.