### PR TITLE
allow -op argument with and without slash

### DIFF
--- a/run_checks.py
+++ b/run_checks.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     # Define output path for checker output
     if opath_in:
         # user-defined path
-        opath = opath_in
+        opath = opath_in + '/'
     else:
         # default path with subdirectory containing timestamp of check
         opathe = start_time.now().strftime("%Y%m%d_%H%M") + '/'


### PR DESCRIPTION
providing -op option like -op mydir was no longer possible after the recent changes. The checker only worked when -op mydir/ was specified. This is a fix for this. 