### PR TITLE
Do not delete content of output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,4 @@ ENV/
 *~
 
 # Ignore checker_output
-checker_output/
+atmodat_checker_output/

--- a/atmodat_checklib/result_output/output_directory.py
+++ b/atmodat_checklib/result_output/output_directory.py
@@ -1,18 +1,19 @@
 """module output_directory.py to create output directory"""
 
 import os
-import shutil
+from datetime import datetime
 
 
 def create_directories(opath, check_types):
+    opath = os.path.join(opath, datetime.now().strftime("%Y%m%d_%H%M"), "")
     # Create directory to store output from checker if it does not exist already
     if not os.path.isdir(opath):
         os.makedirs(opath)
-    else:
-        shutil.rmtree(opath + '/')
-        os.makedirs(opath)
     for check in check_types:
-        os.makedirs(opath + '/' + check)
+        check_dir = opath + check
+        if not os.path.isdir(check_dir):
+            os.makedirs(check_dir)
+    return opath
 
 
 def return_files_in_directory_tree(input_path):

--- a/run_checks.py
+++ b/run_checks.py
@@ -172,6 +172,12 @@ def run_checks(ifile_in, verbose_in, check_types_in, cfversion_in, opath_file, i
     # Get base filename and output path
     filenames_base = [os.path.basename(os.path.realpath(f)).rstrip('.nc') for f in ifile_in]
     for check in check_types_in:
+
+        # Remove preexisting checker output
+        opath_checks = os.path.join(opath_file, check, '')
+        for old_file in os.listdir(opath_checks):
+            os.remove(os.path.join(opath_checks, old_file))
+
         if check == 'atmodat':
             cmd_checker = cmd_string_creation(check, ifile_in, opath_file, filenames_base, idiryml_in, cfversion_in)
             for cmd in cmd_checker:


### PR DESCRIPTION
Fixes #87 

This PR should fix the inadvertent recursive removal of the contents of the output path, defined via the `-op` option. If a pre-existing run with the same timestamp (i.e. you run the checker twice within a minute) is present, only the files generated during the previous checking process will be deleted.

Furthermore, a symbolic link to the output of the latest checker run is created.