### PR TITLE
Specifiy the version numbers/commit hashes and fix setup.py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python>=3.6
+  - python=3.8
   - mamba

--- a/mamba_requirements.txt
+++ b/mamba_requirements.txt
@@ -1,6 +1,6 @@
 pip
 pandas
-compliance-checker
+compliance-checker==4.3.2
 cfunits
 udunits2
 git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
-pyessv
-cc-yaml @ git+https://github.com/cedadev/cc-yaml@master
-compliance-check-lib @ git+https://github.com/cedadev/compliance-check-lib@master
-cfchecker
+pyessv==0.8.4.3
+cc-yaml @ git+https://github.com/cedadev/cc-yaml@70fda996f02e9745ab04453203ccc9e5fc6988c1
+compliance-check-lib @ git+https://github.com/cedadev/compliance-check-lib@c22d8eea1d26a452ceac62ddd22c9a9b4a69599a
+cfchecker==4.1.0
+pandas
+compliance-checker==4.3.2
+cfunits
+pytest

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     include_package_data=True,
     keywords='admodat',
     name="atmodat_check_lib",
-    packages=find_packages(include=["atmodat_check_lib", "atmodat_check_lib.*"]),
+    packages=find_packages(include=["atmodat_checklib", "atmodat_checklib.*"]),
     setup_requires=setup_requirements,
     scripts=["run_checks.py"],
     entry_points={'console_scripts': ['run_checks = run_checks:main']},

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
     name="atmodat_check_lib",
     packages=find_packages(include=["atmodat_check_lib", "atmodat_check_lib.*"]),
     setup_requires=setup_requirements,
+    scripts=["run_checks.py"],
     entry_points={'console_scripts': ['run_checks = run_checks:main']},
     test_suite='tests',
     tests_require=test_requirements,


### PR DESCRIPTION
Closes #94 and closes #95

This PR addresses two issues:
- The version numbers/commit of packages needed to run the checker are now specified. This prevents that a downstream change in a requited package will break the checker.
- Furthermore, this PR fixes the `setup.py` so that one can install the checker from the remote repo without the need to clone it. As not all the requirements can be solved via pip (i.e. `udunits`), there still is a combination of pip and conda to install the necessary packages. The installation instructions for installing the checker from the remote repo via pip are as follows:
  ```bash
  conda create --name atmodat python=3.8 pip udunits
  conda activate atmodat
  pip install git+https://github.com/AtMoDat/atmodat_data_checker@set_version_hash
  ```
  @wachsylon maybe you can have a look at that?